### PR TITLE
fix: allow curl to fail properly

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -18,7 +18,7 @@ _download() {
 
   local download_url="$GH_REPO/releases/download/v${version}/${artifact}"
 
-  curl -Lo "$bin_install_path/${artifact}" "$download_url" || fail "Could not download $download_url"
+  curl -sf -Lo "$bin_install_path/${artifact}" "$download_url" || fail "Could not download $download_url . Is the tool available for ${PLATFORM}-${ar}?"
 }
 
 _download "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH"


### PR DESCRIPTION
Curl needs the '-f' option to give an error code on a failed download, otherwise it will exit with a code 0.

Trying to install in an Intel Mac, as there are no binaries for Mac in the repo, went like this:

```
❯ asdf install nerdctl latest
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9  100     9    0     0     28      0 --:--:-- --:--:-- --:--:--    28
Creating bin directory
Unpacking nerdctl to bin directory
tar: Error opening archive: Unrecognized archive format
```

That error message misleads on the real error happening.

After the change:

```
❯ asdf install nerdctl latest
asdf-nerdctl: Could not download https://github.com/containerd/nerdctl/releases/download/v1.2.0/nerdctl-1.2.0-darwin-amd64.tar.gz . Is the tool available for darwin-amd64?
```

Have a nice day! 😄 